### PR TITLE
Added rename() methods to volumes and snapshots.

### DIFF
--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -96,6 +96,23 @@ class CloudBlockStorageSnapshot(BaseResource):
                 super(CloudBlockStorageSnapshot, self).delete()
 
 
+    def update(self, display_name=None, display_description=None):
+        """
+        Update the specified values on this snapshot. You may specify one or
+        more values to update. If no values are specified as non-None, the call
+        is a no-op; no exception will be raised.
+        """
+        return self.manager.update(self, display_name=display_name,
+                display_description=display_description)
+
+
+    def rename(self, name):
+        """
+        Allows for direct renaming of an existing snapshot.
+        """
+        return self.update(display_name=name)
+
+
     def _get_name(self):
         return self.display_name
 
@@ -185,6 +202,23 @@ class CloudBlockStorageVolume(BaseResource):
             # Notify the user? Record it somewhere?
             # For now, just re-raise
             raise
+
+
+    def update(self, display_name=None, display_description=None):
+        """
+        Update the specified values on this volume. You may specify one or more
+        values to update. If no values are specified as non-None, the call is a
+        no-op; no exception will be raised.
+        """
+        return self.manager.update(self, display_name=display_name,
+                display_description=display_description)
+
+
+    def rename(self, name):
+        """
+        Allows for direct renaming of an existing volume.
+        """
+        return self.update(display_name=name)
 
 
     def create_snapshot(self, name=None, description=None, force=False):
@@ -294,7 +328,8 @@ class CloudBlockStorageManager(BaseManager):
     def update(self, volume, display_name=None, display_description=None):
         """
         Update the specified values on the specified volume. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
         uri = "/%s/%s" % (self.uri_base, utils.get_id(volume))
         param_dict = {}
@@ -380,7 +415,8 @@ class CloudBlockStorageSnapshotManager(BaseManager):
     def update(self, snapshot, display_name=None, display_description=None):
         """
         Update the specified values on the specified snapshot. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
         uri = "/%s/%s" % (self.uri_base, utils.get_id(snapshot))
         param_dict = {}
@@ -449,10 +485,18 @@ class CloudBlockStorageClient(BaseClient):
     def update(self, volume, display_name=None, display_description=None):
         """
         Update the specified values on the specified volume. You may specify
-        one or more values to update.
+        one or more values to update. If no values are specified as non-None,
+        the call is a no-op; no exception will be raised.
         """
-        return self._manager.update(volume, display_name=display_name,
+        return volume.update(display_name=display_name,
                 display_description=display_description)
+
+
+    def rename(self, volume, name):
+        """
+        Allows for direct renaming of an existing volume.
+        """
+        return self.update(volume, display_name=name)
 
 
     @assure_volume
@@ -480,12 +524,19 @@ class CloudBlockStorageClient(BaseClient):
         return snapshot.delete()
 
 
+    @assure_snapshot
     def update_snapshot(self, snapshot, display_name=None,
             display_description=None):
         """
         Update the specified values on the specified snapshot. You may specify
         one or more values to update.
         """
-        return self._snapshot_manager.update(snapshot,
-                display_name=display_name,
+        return snapshot.update(display_name=display_name,
                 display_description=display_description)
+
+
+    def rename_snapshot(self, snapshot, name):
+        """
+        Allows for direct renaming of an existing snapshot.
+        """
+        return self.update_snapshot(snapshot, display_name=name)

--- a/pyrax/fakes.py
+++ b/pyrax/fakes.py
@@ -22,6 +22,7 @@ from pyrax.clouddatabases import CloudDatabaseVolume
 from pyrax.cloudblockstorage import CloudBlockStorageClient
 from pyrax.cloudblockstorage import CloudBlockStorageManager
 from pyrax.cloudblockstorage import CloudBlockStorageSnapshot
+from pyrax.cloudblockstorage import CloudBlockStorageSnapshotManager
 from pyrax.cloudblockstorage import CloudBlockStorageVolume
 from pyrax.cloudloadbalancers import CloudLoadBalancer
 from pyrax.cloudloadbalancers import CloudLoadBalancerManager
@@ -362,6 +363,14 @@ class FakeBlockStorageClient(CloudBlockStorageClient):
         ident = FakeIdentity()
         super(FakeBlockStorageClient, self).__init__(ident, "fakeuser",
                 "fakepassword", *args, **kwargs)
+
+
+class FakeSnapshotManager(CloudBlockStorageSnapshotManager):
+    def __init__(self, api=None, *args, **kwargs):
+        ident = FakeIdentity()
+        if api is None:
+            api = FakeBlockStorageClient(ident)
+        super(FakeSnapshotManager, self).__init__(api, *args, **kwargs)
 
 
 class FakeLoadBalancerClient(CloudLoadBalancerClient):

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -64,7 +64,7 @@ class CloudBlockStorageTest(unittest.TestCase):
 
     def test_assure_volume(self):
         class TestClient(object):
-            _manager = fakes.FakeManager()
+            _manager = fakes.FakeBlockStorageManager()
 
             @assure_volume
             def test_method(self, volume):
@@ -81,7 +81,7 @@ class CloudBlockStorageTest(unittest.TestCase):
 
     def test_assure_snapshot(self):
         class TestClient(object):
-            _snapshot_manager = fakes.FakeManager()
+            _snapshot_manager = fakes.FakeSnapshotManager()
 
             @assure_snapshot
             def test_method(self, snapshot):
@@ -189,7 +189,24 @@ class CloudBlockStorageTest(unittest.TestCase):
                 name=name, description=desc, force=False)
         BaseManager.create = sav
 
-    def test_update_volume(self):
+    def test_vol_update_volume(self):
+        vol = self.volume
+        mgr = vol.manager
+        mgr.update = Mock()
+        nm = utils.random_unicode()
+        desc = utils.random_unicode()
+        vol.update(display_name=nm, display_description=desc)
+        mgr.update.assert_called_once_with(vol, display_name=nm,
+                display_description=desc)
+
+    def test_vol_rename(self):
+        vol = self.volume
+        nm = utils.random_unicode()
+        vol.update = Mock()
+        vol.rename(nm)
+        vol.update.assert_called_once_with(display_name=nm)
+
+    def test_mgr_update_volume(self):
         clt = self.client
         vol = self.volume
         mgr = clt._manager
@@ -202,7 +219,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         mgr.update(vol, display_name=name, display_description=desc)
         mgr.api.method_put.assert_called_once_with(exp_uri, body=exp_body)
 
-    def test_update_volume_empty(self):
+    def test_mgr_update_volume_empty(self):
         clt = self.client
         vol = self.volume
         mgr = clt._manager
@@ -456,6 +473,22 @@ class CloudBlockStorageTest(unittest.TestCase):
         pyrax.cloudblockstorage.RETRY_INTERVAL = 0.1
         self.assertRaises(exc.ClientException, snap.delete)
 
+    def test_snapshot_update(self):
+        snap = self.snapshot
+        snap.manager.update = Mock()
+        nm = utils.random_unicode()
+        desc = utils.random_unicode()
+        snap.update(display_name=nm, display_description=desc)
+        snap.manager.update.assert_called_once_with(snap, display_name=nm,
+                display_description=desc)
+
+    def test_snapshot_rename(self):
+        snap = self.snapshot
+        snap.update = Mock()
+        nm = utils.random_unicode()
+        snap.rename(nm)
+        snap.update.assert_called_once_with(display_name=nm)
+
     def test_volume_name_property(self):
         vol = self.volume
         nm = utils.random_unicode()
@@ -492,7 +525,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         snap.description = nm
         self.assertEqual(snap.description, snap.display_description)
 
-    def test_update_snapshot(self):
+    def test_mgr_update_snapshot(self):
         clt = self.client
         snap = self.snapshot
         mgr = clt._snapshot_manager
@@ -505,7 +538,7 @@ class CloudBlockStorageTest(unittest.TestCase):
         mgr.update(snap, display_name=name, display_description=desc)
         mgr.api.method_put.assert_called_once_with(exp_uri, body=exp_body)
 
-    def test_update_snapshot_empty(self):
+    def test_mgr_update_snapshot_empty(self):
         clt = self.client
         snap = self.snapshot
         mgr = clt._snapshot_manager
@@ -518,20 +551,36 @@ class CloudBlockStorageTest(unittest.TestCase):
         vol = self.volume
         name = utils.random_unicode()
         desc = utils.random_unicode()
-        clt._manager.update = Mock()
+        vol.update = Mock()
         clt.update(vol, display_name=name, display_description=desc)
-        clt._manager.update.assert_called_once_with(vol, display_name=name,
+        vol.update.assert_called_once_with(display_name=name,
                 display_description=desc)
+
+    def test_clt_rename(self):
+        clt = self.client
+        vol = self.volume
+        nm = utils.random_unicode()
+        clt.update = Mock()
+        clt.rename(vol, nm)
+        clt.update.assert_called_once_with(vol, display_name=nm)
 
     def test_clt_update_snapshot(self):
         clt = self.client
         snap = self.snapshot
         name = utils.random_unicode()
         desc = utils.random_unicode()
-        clt._snapshot_manager.update = Mock()
+        snap.update = Mock()
         clt.update_snapshot(snap, display_name=name, display_description=desc)
-        clt._snapshot_manager.update.assert_called_once_with(snap,
-                display_name=name, display_description=desc)
+        snap.update.assert_called_once_with(display_name=name,
+                display_description=desc)
+
+    def test_clt_rename_snapshot(self):
+        clt = self.client
+        snap = self.snapshot
+        nm = utils.random_unicode()
+        clt.update_snapshot = Mock()
+        clt.rename_snapshot(snap, nm)
+        clt.update_snapshot.assert_called_once_with(snap, display_name=nm)
 
     def test_get_snapshot(self):
         clt = self.client


### PR DESCRIPTION
Renaming was always available via the update() methods, but this makes
it more convenient and obvious.

Issue #504