### PR TITLE
Use six or compatible names for Python 2 and 3 compatibility

### DIFF
--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -283,7 +283,7 @@ class CloudBlockStorageManager(BaseManager):
         """
         Used to create the dict required to create a new volume
         """
-        if not isinstance(size, (int, long)) or not (
+        if not isinstance(size, six.integer_types) or not (
                 MIN_SIZE <= size <= MAX_SIZE):
             raise exc.InvalidSize("Volume sizes must be integers between "
                     "%s and %s." % (MIN_SIZE, MAX_SIZE))

--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -61,6 +61,7 @@ MAX_BULK_DELETE = 10000
 class Fault_cls(object):
     def __nonzero__(self):
         return False
+    __bool__ = __nonzero__
 
 FAULT = Fault_cls()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -8,6 +8,7 @@ import pkg_resources
 import requests
 import unittest
 
+import six
 from six.moves import urllib
 
 from mock import patch
@@ -46,7 +47,7 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(ret, expected)
 
     def test_safe_quote_unicode(self):
-        ret = _safe_quote(unichr(1000))
+        ret = _safe_quote(six.unichr(1000))
         expected = "%CF%A8"
         self.assertEqual(ret, expected)
 

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -6,6 +6,7 @@ import os
 import unittest
 import warnings
 
+import six
 from six.moves import reload_module as reload
 
 from mock import patch
@@ -488,8 +489,8 @@ class PyraxInitTest(unittest.TestCase):
         pyrax.get_setting = sav
 
     def test_import_fail(self):
-        import __builtin__
-        sav_import = __builtin__.__import__
+        _builtin = six.moves.builtins
+        sav_import = _builtin.__import__
 
         def fake_import(nm, *args):
             if nm == "identity":
@@ -497,9 +498,9 @@ class PyraxInitTest(unittest.TestCase):
             else:
                 return sav_import(nm, *args)
 
-        __builtin__.__import__ = fake_import
+        _builtin.__import__ = fake_import
         self.assertRaises(ImportError, reload, pyrax)
-        __builtin__.__import__ = sav_import
+        _builtin.__import__ = sav_import
         reload(pyrax)
 
 

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -172,8 +172,8 @@ class ObjectStorageTest(unittest.TestCase):
 
     def test_backwards_aliases(self):
         cont = self.container
-        get_func = cont.get_objects.im_func
-        list_func = cont.list.im_func
+        get_func = cont.get_objects.__func__
+        list_func = cont.list.__func__
         self.assertTrue(get_func is list_func)
 
     def test_repr(self):


### PR DESCRIPTION
* `six.integer_types` is used instead of `(int, long)`, as `long` does not exist in Python 3
* Various renames and moves:
  * `im_func` -> `__func__`
  * `unichar` -> `six.unichar`
  * `__builtin__` -> `six.moves.builtins`