### PR TITLE
Don't hardcode min and max CBS size, just rely on the API to validate. Fixes #538

### DIFF
--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -29,8 +29,6 @@ from pyrax.resource import BaseResource
 import pyrax.utils as utils
 
 
-MIN_SIZE = 100
-MAX_SIZE = 1024
 RETRY_INTERVAL = 5
 
 
@@ -283,10 +281,11 @@ class CloudBlockStorageManager(BaseManager):
         """
         Used to create the dict required to create a new volume
         """
-        if not isinstance(size, (int, long)) or not (
-                MIN_SIZE <= size <= MAX_SIZE):
-            raise exc.InvalidSize("Volume sizes must be integers between "
-                    "%s and %s." % (MIN_SIZE, MAX_SIZE))
+        try:
+            int(size)
+        except:
+            raise exc.InvalidSize("Volume sizes must be integers")
+
         if volume_type is None:
             volume_type = "SATA"
         if description is None:

--- a/tests/unit/test_cloud_blockstorage.py
+++ b/tests/unit/test_cloud_blockstorage.py
@@ -17,8 +17,6 @@ from pyrax.cloudblockstorage import _resolve_id
 from pyrax.cloudblockstorage import _resolve_name
 from pyrax.cloudblockstorage import assure_volume
 from pyrax.cloudblockstorage import assure_snapshot
-from pyrax.cloudblockstorage import MIN_SIZE
-from pyrax.cloudblockstorage import MAX_SIZE
 import pyrax.exceptions as exc
 from pyrax.manager import BaseManager
 import pyrax.utils as utils
@@ -255,26 +253,24 @@ class CloudBlockStorageTest(unittest.TestCase):
     def test_create_body_volume_bad_size(self):
         mgr = self.client._manager
         self.assertRaises(exc.InvalidSize, mgr._create_body, "name",
-                size=MIN_SIZE - 1)
-        self.assertRaises(exc.InvalidSize, mgr._create_body, "name",
-                size=MAX_SIZE + 1)
+                size='foo')
 
     def test_create_volume_bad_clone_size(self):
         mgr = self.client._manager
         mgr._create = Mock(side_effect=exc.BadRequest(400,
                 "Clones currently must be >= original volume size"))
         self.assertRaises(exc.VolumeCloneTooSmall, mgr.create, "name",
-                size=MIN_SIZE, clone_id=utils.random_unicode())
+                size=100, clone_id=utils.random_unicode())
 
     def test_create_volume_fail_other(self):
         mgr = self.client._manager
         mgr._create = Mock(side_effect=exc.BadRequest(400, "FAKE"))
         self.assertRaises(exc.BadRequest, mgr.create, "name",
-                size=MIN_SIZE, clone_id=utils.random_unicode())
+                size=100, clone_id=utils.random_unicode())
 
     def test_create_body_volume(self):
         mgr = self.client._manager
-        size = random.randint(MIN_SIZE, MAX_SIZE)
+        size = random.randint(100, 1024)
         name = utils.random_unicode()
         snapshot_id = utils.random_unicode()
         clone_id = utils.random_unicode()
@@ -301,7 +297,7 @@ class CloudBlockStorageTest(unittest.TestCase):
 
     def test_create_body_volume_defaults(self):
         mgr = self.client._manager
-        size = random.randint(MIN_SIZE, MAX_SIZE)
+        size = random.randint(100, 1024)
         name = utils.random_unicode()
         snapshot_id = utils.random_unicode()
         clone_id = utils.random_unicode()


### PR DESCRIPTION
Currently `MIN_SIZE` and `MAX_SIZE` are hardcoded.  I don't feel this is super maintainable, since it would require a new release every time those values change.

Just rely on the API to validate the sizes.