### PR TITLE
Segment large files for upload without needing tons of RAM

### DIFF
--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -1909,8 +1909,11 @@ class StorageObjectManager(BaseManager):
             sequence = str(segment + 1).zfill(digits)
             seg_name = "%s.%s" % (obj_name, sequence)
             with utils.SelfDeletingTempfile() as tmpname:
+                # Write the temporary file in small pieces, to be memory efficient.
                 with open(tmpname, "wb") as tmp:
-                    tmp.write(content.read(MAX_FILE_SIZE))
+                    for chunk in utils.read_in_chunks(content,
+                            max_size=MAX_FILE_SIZE):
+                        tmp.write(chunk)
                 with open(tmpname, "rb") as tmp:
                     # We have to calculate the etag for each segment
                     etag = utils.get_checksum(tmp)

--- a/pyrax/utils.py
+++ b/pyrax/utils.py
@@ -784,3 +784,17 @@ def to_slug(value, incoming=None, errors="strict"):
 
 # For backwards compatibility, alias slugify to point to_slug
 slugify = to_slug
+
+def read_in_chunks(file_object, max_size, chunk_size=8192):
+    bytes_left_to_read = int(max_size)
+    chunk_size = int(chunk_size)
+    # Set read size to pick the smaller of the two values
+    # in case max_size is smaller than the default chunk size
+    read_size = min(max_size, chunk_size)
+    while read_size > 0:
+        data = file_object.read(read_size)
+        bytes_left_to_read -= chunk_size
+        read_size = min(bytes_left_to_read, chunk_size)
+        if not data:
+            break
+        yield data

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -422,6 +422,54 @@ class UtilsTest(unittest.TestCase):
         ret = utils.update_exc(err, msg2, before=False, separator=sep)
         self.assertEqual(ret.message, exp)
 
+    def test_read_in_chunks(self):
+        # create junk file to test size.
+        source_file = "source_file.dat"
+        target_file = "target_file.dat"
+        def compare_contents(source_file_name, target_file_name):
+            # compare whatever is contained in the target file to the first part of the source file
+            with open(source_file_name, "rb") as source_handle, open(target_file_name, "rb") as target_handle:
+                read_size = os.path.getsize(target_file_name)
+                target_contents = target_handle.read(read_size)
+                source_contents = source_handle.read(read_size)
+                self.assertEqual(target_contents, source_contents)
+        # Try block is just to make sure we delete the files.
+        # Using only main python libraries to hopefully improve test reliability.
+        try:
+            # Write something into the source file
+            with open(source_file, "wb") as source:
+                source.write(os.urandom(1024))
+            # Make sure it's the size we're expecting
+            self.assertEqual(1024, os.path.getsize(source_file))
+            # Now test different sizing cases for file consistency.
+            # test max_size smaller than chunk size
+            with open(target_file, "wb") as target, open(source_file, "rb") as source:
+                for chunk in utils.read_in_chunks(source, max_size=1, chunk_size=1024):
+                    target.write(chunk)
+                compare_contents(source_file, target_file)
+            os.unlink(target_file)
+            # test max_size larger than chunk size
+            with open(target_file, "wb") as target, open(source_file, "rb") as source:
+                for chunk in utils.read_in_chunks(source, max_size=512, chunk_size=64):
+                    target.write(chunk)
+                compare_contents(source_file, target_file)
+            os.unlink(target_file)
+            # test max_size equal with chunk size
+            with open(target_file, "wb") as target, open(source_file, "rb") as source:
+                for chunk in utils.read_in_chunks(source, max_size=512, chunk_size=512):
+                    target.write(chunk)
+                compare_contents(source_file, target_file)
+            os.unlink(target_file)
+            os.unlink(source_file)
+
+        except:
+            raise
+        finally:
+            # Remove the test files we made!
+            if os.path.exists(source_file):
+                os.unlink(source_file)
+            if os.path.exists(target_file):
+                os.unlink(target_file)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### Reason for the changes and pull request:
This change addresses a bug I found. I'd try to upload a file larger than 5 GB, relying on pyrax to segment and handle the metadata for me, but it gave me a ```MemoryError```.

```
project_container_name = "BigDataUploadTest"
# File that's > 5 GB
backup_file = "/data/tmp/SomeBigTarBall.tar.bz2"
# Get container
project_container = cloudfiles.get_container(project_container_name)
# Set checksum
checksum = pyrax.utils.get_checksum(backup_file)
#Upload file. Throws a python MemoryError
project_container.upload_file(backup_file, etag=checksum)
```

Inspecting the code showed that the function was trying to read 5 GB of the file into memory before writing to the disk.
```
# Maximum size of a stored object: 5GB - 1
MAX_FILE_SIZE = 5368709119
```
...
```
tmp.write(content.read(MAX_FILE_SIZE))
```
This didn't work on my 1 GB cloud server, of course. This should nicely resolve the issue for myself and for others.

The ```StorageObjectManager._upload``` function will now read and write in small pieces until the segment reaches the desired size, and it seems to work perfectly, especially with the self-deleting tmp file utility function.

I only found this issue in the one place, but it's possible it ought to be applied elswhere. If other  file segmenting is done on the disk, the new function can be used easily.

#### Changes made
The function read_in_chunks by default reads in pieces of 8192 bytes (8 Kb) so even memory constrained boxes shouldn't have problems segmenting large files if they have enough disk space. This function required a new function in pyrax.utils

The following changes were made: 
- Modifying the StorageObjectManager._upload function to use the new function in pyrax/object_storage.py
- a new function in pyrax/utils.py
- a new test case in tests/unit/test_utils.py which tests the new function

### Other stuff:
- I made sure to follow your instructions here:
    https://github.com/rackspace/pyrax/blob/master/HACKING.rst
- I checked for pep8 standards compliance, and it passed (after a tiny bit of work)
- I added a unittest and everything else passed as well.

Obviously you'll want to verify everything, but I've done what I know to do on my end.
Let me know if I can do anything to help.