### PR TITLE
Added a default for entity in pyrax.cloudmonitoring.CloudMonitorAlarm…

### DIFF
--- a/pyrax/cloudmonitoring.py
+++ b/pyrax/cloudmonitoring.py
@@ -955,7 +955,7 @@ class CloudMonitorAlarm(BaseResource):
     Alarms bind alerting rules, entities, and notification plans into a logical
     unit.
     """
-    def __init__(self, manager, info, entity, key=None, loaded=False):
+    def __init__(self, manager, info, entity=None, key=None, loaded=False):
         super(CloudMonitorAlarm, self).__init__(manager, info, key=key,
                 loaded=loaded)
         if entity is None:


### PR DESCRIPTION
….__init__

Related to issue #566.
https://github.com/rackspace/pyrax/blob/da6ff9c4c9c0295188aadae87a27aa793c1634e8/pyrax/manager.py#L159 assumes that all classes have 2 positional parameters in their constructors while CloudMonitorAlarm has three.