### PR TITLE
Fix novaclient _discover_extensions bug

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -56,7 +56,7 @@ try:
 
     from novaclient import exceptions as _cs_exceptions
     from novaclient import auth_plugin as _cs_auth_plugin
-    from novaclient.shell import OpenStackComputeShell as _cs_shell
+    from novaclient import client as nc
     from novaclient.v1_1 import client as _cs_client
     from novaclient.v1_1.servers import Server as CloudServer
 
@@ -675,8 +675,7 @@ def connect_to_cloudservers(region=None, context=None, verify_ssl=None, **kwargs
         insecure = not get_setting("verify_ssl")
     else:
         insecure = not verify_ssl
-    cs_shell = _cs_shell()
-    extensions = cs_shell._discover_extensions("1.1")
+    extensions = nc.discover_extensions("1.1")
     cloudservers = _cs_client.Client(context.username, context.password,
             project_id=context.tenant_id, auth_url=context.auth_endpoint,
             auth_system=id_type, region_name=region, service_type="compute",


### PR DESCRIPTION
python-novaclient removed
novaclient.shell.OpenStackComputeShell._discover_extensions()
in favor of novaclient._discover_extensions()
https://github.com/openstack/python-novaclient/commit/cb7be1281a6487692d9b7301bd19b9f4de4bda31