### PR TITLE
Pin novaclient to 2.27.0 or less

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -37,6 +37,10 @@ import re
 import six.moves.configparser as ConfigParser
 import warnings
 
+# Ignore UserWarnings. Currently we're getting warnings about novaclient.v1_1
+# deprecations as UserWarning instead of DeprecationWarning (why?).
+warnings.filterwarnings("ignore", ".*novaclient.v1_1 is deprecated.*")
+
 # keyring is an optional import
 try:
     import keyring

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "python-novaclient>=2.13.0",
+        "python-novaclient>=2.13.0,<=2.27.0",
         "rackspace-novaclient",
         "keyring",
         "requests>=2.2.1",


### PR DESCRIPTION
As we're not actively following novaclient developments, and we're not moving off of the v1_1 client, pin novaclient less or equal to the 2.27.0 release and silence that warning.