### PR TITLE
example `target_hostname` value should be a FQDN, not a URL

### DIFF
--- a/docs/cloud_monitoring.md
+++ b/docs/cloud_monitoring.md
@@ -138,7 +138,7 @@ To create the check, run the following:
     chk = cm.create_check(ent, label="sample_check", check_type="remote.http",
             details={"url": "http://example.com/some_page"}, period=900,
             timeout=20, monitoring_zones_poll=["mzdfw", "mzlon", "mzsyd"],
-            target_hostname="http://example.com")
+            target_hostname="example.com")
 
 This will create an HTTP check on the entity `ent` for the page `http://example.com/some_page` that will run every 15 minutes from the Dallas, London, and Sydney monitoring zones.
 


### PR DESCRIPTION
I've tested this against pyrax==1.9.5, and it seems to only allow FQDNs, not URLs.