### PR TITLE
Fix #590: _resolve_device_type() doesn't recognise CloudServer

### DIFF
--- a/pyrax/clouddns.py
+++ b/pyrax/clouddns.py
@@ -31,6 +31,8 @@ from pyrax.manager import BaseManager
 from pyrax.resource import BaseResource
 import pyrax.utils as utils
 
+from novaclient.v2.servers import Server as CloudServer
+
 # How long (in seconds) to wait for a response from async operations
 DEFAULT_TIMEOUT = 5
 # How long (in seconds) to wait in between checks for async completion
@@ -928,12 +930,12 @@ class CloudDNSManager(BaseManager):
         """
         try:
             from tests.unit import fakes
-            server_types = (pyrax.CloudServer, fakes.FakeServer)
+            server_types = (CloudServer, fakes.FakeServer)
             lb_types = (CloudLoadBalancer, fakes.FakeLoadBalancer,
                     fakes.FakeDNSDevice)
         except ImportError:
             # Not running with tests
-            server_types = (pyrax.CloudServer, )
+            server_types = (CloudServer, )
             lb_types = (CloudLoadBalancer, )
         if isinstance(device, server_types):
             device_type = "server"


### PR DESCRIPTION
Sorry, couldn't see how to add a test for this - the existing tests use fakes.FakeDNSDevice() which is why they don't pick up on the problem. But this does it for me :smile: 