### PR TITLE
Update references to novaclient 1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "python-novaclient>=2.13.0,<=2.27.0",
+        "python-novaclient>=2.27.0",
         "rackspace-novaclient",
         "keyring",
         "requests>=2.2.1",


### PR DESCRIPTION
Recent releases of novaclient removed the references to the v1.1 client.
This patch updates the import statements to refer to the v2 client, and
also updates the check for the 1.1 extensions. The required version for
python-novaclient has also been increased to use 2.27.0 as the minimum.