### PR TITLE
Update import statements to ref novaclient.v2

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -61,8 +61,8 @@ try:
     from novaclient import exceptions as _cs_exceptions
     from novaclient import auth_plugin as _cs_auth_plugin
     from novaclient import client as nc
-    from novaclient.v1_1 import client as _cs_client
-    from novaclient.v1_1.servers import Server as CloudServer
+    from novaclient.v2 import client as _cs_client
+    from novaclient.v2.servers import Server as CloudServer
 
     from .autoscale import AutoScaleClient
     from .cloudcdn import CloudCDNClient


### PR DESCRIPTION
__init__.py file novaclient imports still ref v1.1 
Issue #544 still not addressed if attempting to import v1.1
Updated to v2