### PR TITLE
Changing endpoint management to respect service prefixes

### DIFF
--- a/pyrax/__init__.py
+++ b/pyrax/__init__.py
@@ -121,17 +121,17 @@ services = tuple()
 
 _client_classes = {
         "compute": _cs_client.Client,
-        "cdn": CloudCDNClient,
+        "rax:cdn": CloudCDNClient,
         "object_store": StorageClient,
-        "database": CloudDatabaseClient,
-        "load_balancer": CloudLoadBalancerClient,
+        "rax:database": CloudDatabaseClient,
+        "rax:load_balancer": CloudLoadBalancerClient,
         "volume": CloudBlockStorageClient,
-        "dns": CloudDNSClient,
-        "compute:network": CloudNetworkClient,
-        "monitor": CloudMonitorClient,
-        "autoscale": AutoScaleClient,
+        "rax:dns": CloudDNSClient,
+        "network": CloudNetworkClient,
+        "rax:monitor": CloudMonitorClient,
+        "rax:autoscale": AutoScaleClient,
         "image": ImageClient,
-        "queues": QueueClient,
+        "rax:queues": QueueClient,
         }
 
 
@@ -739,21 +739,22 @@ def connect_to_cloudfiles(region=None, public=None):
     if ret:
         # Add CDN endpoints, if available
         region = _safe_region(region)
-        ret.cdn_management_url = _get_service_endpoint(None, "object_cdn",
+        ret.cdn_management_url = _get_service_endpoint(None, "rax:object_cdn",
                 region, public=is_public)
     return ret
 
 
 @_require_auth
-def _create_client(ep_name, region, public=True, verify_ssl=None):
+def _create_client(ep_name, region, public=True, verify_ssl=None, class_name=None):
     region = _safe_region(region)
-    ep = _get_service_endpoint(None, ep_name.split(":")[0], region,
+    ep = _get_service_endpoint(None, ep_name, region,
             public=public)
     if not ep:
         return
     if verify_ssl is None:
         verify_ssl = get_setting("verify_ssl")
-    cls = _client_classes[ep_name]
+    client_classname = class_name if class_name else ep_name
+    cls = _client_classes[client_classname]
     client = cls(identity, region_name=region, management_url=ep,
             verify_ssl=verify_ssl, http_log_debug=_http_debug)
     client.user_agent = _make_agent_name(client.user_agent)
@@ -762,17 +763,17 @@ def _create_client(ep_name, region, public=True, verify_ssl=None):
 
 def connect_to_cloud_databases(region=None):
     """Creates a client for working with cloud databases."""
-    return _create_client(ep_name="database", region=region)
+    return _create_client(ep_name="rax:database", region=region)
 
 
 def connect_to_cloud_cdn(region=None):
     """Creates a client for working with cloud loadbalancers."""
-    return _create_client(ep_name="cdn", region=region)
+    return _create_client(ep_name="rax:cdn", region=region)
 
 
 def connect_to_cloud_loadbalancers(region=None):
     """Creates a client for working with cloud loadbalancers."""
-    return _create_client(ep_name="load_balancer", region=region)
+    return _create_client(ep_name="rax:load_balancer", region=region)
 
 
 def connect_to_cloud_blockstorage(region=None):
@@ -782,22 +783,22 @@ def connect_to_cloud_blockstorage(region=None):
 
 def connect_to_cloud_dns(region=None):
     """Creates a client for working with cloud dns."""
-    return _create_client(ep_name="dns", region=region)
+    return _create_client(ep_name="rax:dns", region=region)
 
 
 def connect_to_cloud_networks(region=None):
     """Creates a client for working with cloud networks."""
-    return _create_client(ep_name="compute:network", region=region)
+    return _create_client(ep_name="compute", region=region, class_name="network")
 
 
 def connect_to_cloud_monitoring(region=None):
     """Creates a client for working with cloud monitoring."""
-    return _create_client(ep_name="monitor", region=region)
+    return _create_client(ep_name="rax:monitor", region=region)
 
 
 def connect_to_autoscale(region=None):
     """Creates a client for working with AutoScale."""
-    return _create_client(ep_name="autoscale", region=region)
+    return _create_client(ep_name="rax:autoscale", region=region)
 
 
 def connect_to_images(region=None, public=True):
@@ -807,7 +808,7 @@ def connect_to_images(region=None, public=True):
 
 def connect_to_queues(region=None, public=True):
     """Creates a client for working with Queues."""
-    return _create_client(ep_name="queues", region=region, public=public)
+    return _create_client(ep_name="rax:queues", region=region, public=public)
 
 
 def client_class_for_service(service):

--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -66,13 +66,13 @@ class Service(object):
         self.identity = identity
         self.name = catalog.get("name")
         # Replace any dashes with underscores.
-        fulltype = catalog["type"].replace("-", "_")
+        self.fulltype = catalog["type"].replace("-", "_")
         # Some provider-specific services are prefixed with that info.
         try:
-            self.prefix, self.service_type = fulltype.split(":")
+            self.prefix, self.service_type = self.fulltype.split(":")
         except ValueError:
             self.prefix = ""
-            self.service_type = fulltype
+            self.service_type = self.fulltype
         if self.service_type == "compute":
             if self.name.lower() == "cloudservers":
                 # First-generation Rackspace cloud servers
@@ -82,7 +82,7 @@ class Service(object):
         eps = catalog.get("endpoints", [])
         for ep in eps:
             rgn = ep.get("region", "ALL")
-            self.endpoints[rgn] = Endpoint(ep, self.service_type, rgn, identity,
+            self.endpoints[rgn] = Endpoint(ep, self.fulltype, rgn, identity,
                                            verify_ssl=self.identity.verify_ssl)
         return
 
@@ -297,21 +297,21 @@ class BaseIdentity(object):
                 "nova": "compute",
                 "cloudfiles": "object_store",
                 "swift": "object_store",
-                "cloud_loadbalancers": "load_balancer",
-                "cloud_databases": "database",
-                "trove": "database",
+                "cloud_loadbalancers": "rax:load_balancer",
+                "cloud_databases": "rax:database",
+                "trove": "rax:database",
                 "cloud_blockstorage": "volume",
                 "cinder": "volume",
-                "cloud_dns": "dns",
-                "designate": "dns",
-                "cloud_networks": "raxnetwork",
+                "cloud_dns": "rax:dns",
+                "designate": "rax:dns",
+                "cloud_networks": "compute",
                 "neutron": "network",
-                "cloud_monitoring": "monitor",
-                "autoscale": "autoscale",
+                "cloud_monitoring": "rax:monitor",
+                "autoscale": "rax:autoscale",
                 "images": "image",
                 "glance": "image",
-                "queues": "queues",
-                "marconi": "queues",
+                "queues": "rax:queues",
+                "marconi": "rax:queues",
                 }
 
 
@@ -648,7 +648,7 @@ class BaseIdentity(object):
             if not hasattr(service, "endpoints"):
                 # Not an OpenStack service
                 continue
-            setattr(self.services, service.service_type, service)
+            setattr(self.services, service.fulltype, service)
             self.regions.update(list(service.endpoints.keys()))
         # Update the 'ALL' services to include all available regions.
         self.regions.discard("ALL")

--- a/pyrax/fakes.py
+++ b/pyrax/fakes.py
@@ -828,6 +828,11 @@ fake_identity_response = {u'access':
         'name': 'cloudDNS',
         'type': 'rax:dns'},
         {u'endpoints': [{u'publicURL':
+        'https://global.dns.api.rackspacecloud.com/v2/000000',
+        'tenantId': '000000'}],
+        'name': 'Managed DNS',
+        'type': 'dns'},
+        {u'endpoints': [{u'publicURL':
             'https://dfw.databases.api.rackspacecloud.com/v1.0/000000',
             'region': 'DFW',
             'tenantId': '000000'},

--- a/pyrax/object_storage.py
+++ b/pyrax/object_storage.py
@@ -2219,7 +2219,7 @@ class StorageClient(BaseClient):
         Initialize CDN-related endpoints, if available.
         """
         ident = self.identity
-        cdn_svc = ident.services.get("object_cdn")
+        cdn_svc = ident.services.get("rax:object_cdn")
         if cdn_svc:
             ep = cdn_svc.endpoints.get(self.region_name)
             if ep:

--- a/tests/unit/test_object_storage.py
+++ b/tests/unit/test_object_storage.py
@@ -2344,7 +2344,7 @@ class ObjectStorageTest(unittest.TestCase):
         fake_service = fakes.FakeService()
         fake_ep = fakes.FakeEndpoint()
         fake_ep.public_url = utils.random_unicode()
-        ident.services["object_cdn"] = fake_service
+        ident.services["rax:object_cdn"] = fake_service
         fake_service.endpoints = {clt.region_name: fake_ep}
         clt._configure_cdn()
         self.assertEqual(clt.cdn_management_url, fake_ep.public_url)


### PR DESCRIPTION
See #595 

This fix requires widespread changes to references to service endpoint types.