### PR TITLE
Exclude Managed DNS from service registration to avoid conflict with Cloud DNS

### DIFF
--- a/pyrax/base_identity.py
+++ b/pyrax/base_identity.py
@@ -648,6 +648,10 @@ class BaseIdentity(object):
             if not hasattr(service, "endpoints"):
                 # Not an OpenStack service
                 continue
+            if service.prefix == '' and service.service_type == 'dns':
+                # Skip service registration of Managed DNS
+                # so it doesn't conflict with Cloud DNS
+                continue
             setattr(self.services, service.service_type, service)
             self.regions.update(list(service.endpoints.keys()))
         # Update the 'ALL' services to include all available regions.


### PR DESCRIPTION
See #595 

This fix is more limited in scope than #597 and simply excludes Managed DNS from service registration.