### PR TITLE
Fix memory hole while uploading 5G chunks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class sdist(_sdist):
         # Expand macros in pyrax.spec.in
         spec_in = open('pyrax.spec.in', 'r')
         spec = open('pyrax.spec', 'w')
-        for line in spec_in.xreadlines():
+        for line in spec_in:
             if "@VERSION@" in line:
                 line = line.replace("@VERSION@", version)
             elif "@RELEASE@" in line:

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,8 @@ deps =
 
 commands =
     {envbindir}/pep8 -r --show-source --max-line-length=84 --ignore=E123,E124,E126,E127,E128,E303,E302 pyrax/
+
+[testenv:pypy]
+deps =
+    requests
+    nose


### PR DESCRIPTION
The call read(MAX_FILE_SIZE) will load the hole MAX_FILE_SIZE into
memory, which turns to be 5GB. That puts the system to a crawl.

Instead, the better way to go around this is to use streaming, copying
small chunks of memory in a loop until all bytes are transferred.
Python provides shutil.copyfileobj that saves you even writting the loop
explicitly.

Apart from that:
- xreadlines has been deperectaed for quite a while now:
  https://www.quantifiedcode.com/knowledge-base/maintainability/%60.xreadlines()%60%20deprecated/7lC2NACa
- Tox was not able to run pypy test env properly without the explicit
  dependencies on requests and nose.